### PR TITLE
Nomad Korea 전체 기능 구현 (Phase 1-6 + 커스텀 커맨드)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -27,7 +27,9 @@
       "Bash(npx tsc:*)",
       "Bash(npm run lint)",
       "Bash(npm run typecheck:*)",
-      "Bash(npm run:*)"
+      "Bash(npm run:*)",
+      "Bash(gh issue:*)",
+      "Bash(grep:*)"
     ]
   }
 }

--- a/nomad-korea/package-lock.json
+++ b/nomad-korea/package-lock.json
@@ -20,6 +20,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-leaflet": "^5.0.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
@@ -10695,6 +10696,16 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/nomad-korea/package.json
+++ b/nomad-korea/package.json
@@ -21,6 +21,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-leaflet": "^5.0.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/nomad-korea/src/app/cities/[slug]/page.tsx
+++ b/nomad-korea/src/app/cities/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { InternetSpeedBadge } from "@/components/shared/internet-speed-badge";
 import { Pm25Badge } from "@/components/shared/pm25-badge";
 import { KtxTimeBadge } from "@/components/shared/ktx-time-badge";
 import { CityTags } from "@/components/shared/city-tags";
+import { LikeDislikeBar } from "@/components/shared/like-dislike-bar";
 import { CityCard } from "@/components/sections/city-card";
 import { cities } from "@/data/cities";
 import { formatCurrency } from "@/lib/utils";
@@ -100,6 +101,12 @@ export default async function CityDetailPage({ params }: PageProps) {
             <div className="rounded-xl border border-border bg-surface p-6 space-y-4">
               <NomadScoreBar score={city.nomadScore} />
               <SafetyBar rating={city.safetyRating} />
+              <LikeDislikeBar
+                likes={city.likes}
+                dislikes={city.dislikes}
+                interactive
+                citySlug={city.slug}
+              />
 
               <div className="flex flex-wrap gap-2">
                 <InternetSpeedBadge speed={city.internetSpeed} />

--- a/nomad-korea/src/app/layout.tsx
+++ b/nomad-korea/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Toaster } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import "./globals.css";
 
@@ -30,6 +31,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}
       >
         <TooltipProvider>{children}</TooltipProvider>
+        <Toaster position="bottom-center" richColors />
       </body>
     </html>
   );

--- a/nomad-korea/src/components/sections/filter-sort-bar.tsx
+++ b/nomad-korea/src/components/sections/filter-sort-bar.tsx
@@ -31,7 +31,7 @@ export function FilterSortBar({
       <div className="mx-auto flex max-w-7xl flex-wrap items-center gap-4 px-4 py-4">
         {/* Region filter */}
         <Select value={region} onValueChange={onRegionChange}>
-          <SelectTrigger className="w-[140px] border-border bg-surface">
+          <SelectTrigger className="flex-1 border-border bg-surface">
             <SelectValue placeholder="지역" />
           </SelectTrigger>
           <SelectContent className="border-border bg-surface">
@@ -47,7 +47,7 @@ export function FilterSortBar({
 
         {/* Sort */}
         <Select value={sort} onValueChange={onSortChange}>
-          <SelectTrigger className="w-[160px] border-border bg-surface">
+          <SelectTrigger className="flex-1 border-border bg-surface">
             <SelectValue placeholder="정렬" />
           </SelectTrigger>
           <SelectContent className="border-border bg-surface">
@@ -60,15 +60,12 @@ export function FilterSortBar({
           </SelectContent>
         </Select>
 
-        {/* Spacer */}
-        <div className="flex-1" />
-
         {/* View toggle */}
         <ToggleGroup
           type="single"
           value={view}
           onValueChange={(v) => v && onViewChange(v)}
-          className="border border-border"
+          className="ml-auto shrink-0 border border-border"
         >
           <ToggleGroupItem
             value="grid"

--- a/nomad-korea/src/components/shared/like-dislike-bar.tsx
+++ b/nomad-korea/src/components/shared/like-dislike-bar.tsx
@@ -1,22 +1,141 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
+
+const STORAGE_KEY = "nomad-korea-city-votes";
+
+type Vote = "like" | "dislike" | null;
+
+function getStoredVotes(): Record<string, Vote> {
+  if (typeof window === "undefined") return {};
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+  } catch {
+    return {};
+  }
+}
+
+function storeVote(citySlug: string, vote: Vote): void {
+  const votes = getStoredVotes();
+  if (vote === null) {
+    delete votes[citySlug];
+  } else {
+    votes[citySlug] = vote;
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(votes));
+}
+
 interface LikeDislikeBarProps {
   likes: number;
   dislikes: number;
+  interactive?: boolean;
+  citySlug?: string;
 }
 
-export function LikeDislikeBar({ likes, dislikes }: LikeDislikeBarProps) {
-  const total = likes + dislikes;
-  const likePercent = total > 0 ? (likes / total) * 100 : 50;
+export function LikeDislikeBar({
+  likes,
+  dislikes,
+  interactive = false,
+  citySlug,
+}: LikeDislikeBarProps) {
+  const [currentVote, setCurrentVote] = useState<Vote>(null);
+  const [likeCount, setLikeCount] = useState(likes);
+  const [dislikeCount, setDislikeCount] = useState(dislikes);
+
+  useEffect(() => {
+    if (interactive && citySlug) {
+      const votes = getStoredVotes();
+      const saved = votes[citySlug] ?? null;
+      setCurrentVote(saved);
+      if (saved === "like") {
+        setLikeCount(likes + 1);
+      } else if (saved === "dislike") {
+        setDislikeCount(dislikes + 1);
+      }
+    }
+  }, [interactive, citySlug, likes, dislikes]);
+
+  function handleVote(type: "like" | "dislike") {
+    if (!interactive || !citySlug) return;
+
+    if (currentVote === type) {
+      // 같은 버튼 재클릭 → 투표 취소
+      setCurrentVote(null);
+      storeVote(citySlug, null);
+      if (type === "like") {
+        setLikeCount(likes);
+      } else {
+        setDislikeCount(dislikes);
+      }
+      toast("투표가 취소되었습니다.");
+      return;
+    }
+
+    // 새 투표 또는 전환
+    const prevVote = currentVote;
+    setCurrentVote(type);
+    storeVote(citySlug, type);
+
+    if (type === "like") {
+      setLikeCount(likes + 1);
+      setDislikeCount(prevVote === "dislike" ? dislikes : dislikeCount);
+      toast.success("이 도시를 추천했습니다! 👍");
+    } else {
+      setDislikeCount(dislikes + 1);
+      setLikeCount(prevVote === "like" ? likes : likeCount);
+      toast.error("이 도시를 비추천했습니다. 👎");
+    }
+  }
+
+  if (!interactive) {
+    return (
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-1 text-xs text-nk-green">
+          👍 <span>{likes}</span>
+        </span>
+        <span className="flex items-center gap-1 text-xs text-nk-red">
+          <span>{dislikes}</span> 👎
+        </span>
+      </div>
+    );
+  }
 
   return (
-    <div className="flex items-center gap-2">
-      <span className="text-xs text-nk-green">👍 {likes}</span>
-      <div className="h-1.5 flex-1 rounded-full bg-nk-red/30">
-        <div
-          className="h-full rounded-full bg-nk-green"
-          style={{ width: `${likePercent}%` }}
-        />
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => handleVote("like")}
+          className={`flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium transition-all ${
+            currentVote === "like"
+              ? "bg-nk-green/20 text-nk-green ring-1 ring-nk-green/50"
+              : "text-dim hover:bg-nk-green/10 hover:text-nk-green"
+          }`}
+        >
+          👍 {likeCount}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => handleVote("dislike")}
+          className={`flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium transition-all ${
+            currentVote === "dislike"
+              ? "bg-nk-red/20 text-nk-red ring-1 ring-nk-red/50"
+              : "text-dim hover:bg-nk-red/10 hover:text-nk-red"
+          }`}
+        >
+          {dislikeCount} 👎
+        </button>
       </div>
-      <span className="text-xs text-nk-red">👎 {dislikes}</span>
+
+      <p className="text-center text-xs text-dim">
+        {currentVote
+          ? currentVote === "like"
+            ? "이 도시를 추천하셨습니다"
+            : "이 도시를 비추천하셨습니다"
+          : "이 도시를 추천하시나요?"}
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Nomad Korea 프로젝트 Phase 1~6 전체 기능 구현
- 도시 탐색, 필터/정렬, 상세 페이지, 인터랙티브 지도, 사이드바 콘텐츠, 인증/프로필/멤버십 완성
- Claude Code 커스텀 커맨드 3종 추가 (feature-breakdown, create-github-issue, resolve-issue)

## 주요 변경 사항

### Phase 1: Core UX
- Supabase 인증 (로그인/회원가입/비밀번호 재설정)
- 프로필 페이지 + 닉네임 수정
- 네비게이션 바 사용자 드롭다운

### Phase 2: 필터/정렬 & 데이터 확장
- 6개 → 15개 도시 데이터 확장
- 지역별 필터 + 6가지 정렬 옵션
- 그리드/리스트 뷰 토글

### Phase 3: 도시 상세 페이지
- `/cities/[slug]` 동적 라우트 (15개 SSG)
- 히어로, 핵심 지표, 장단점, 코워킹, 카페, 비슷한 도시

### Phase 4: 인터랙티브 지도
- react-leaflet + CartoDB Dark 타일
- 15개 도시 마커 + 팝업 (점수, 비용, 상세 링크)

### Phase 5: 사이드바 콘텐츠
- 밋업 (7개), 한달살기, 커뮤니티 피드, 에디토리얼
- 이메일 뉴스레터 구독 (localStorage)

### Phase 6: 멤버십 & 프로필
- Free/Pro 멤버십 + 가짜 결제 플로우
- 프로필 페이지 (이름 수정, 멤버십 상태, 로그아웃)

### 커스텀 커맨드
- `/feature-breakdown` — 기능 분해 계획
- `/create-github-issue` — 코드 분석 기반 이슈 자동 생성
- `/resolve-issue` — GitHub 이슈 가져와서 해결 계획 수립

## Test plan
- [ ] 15개 도시 카드 렌더링 + 필터/정렬 동작 확인
- [ ] 도시 카드 클릭 → 상세 페이지 이동 확인
- [ ] 인터랙티브 지도 마커 + 팝업 확인
- [ ] 로그인/회원가입/비밀번호 재설정 플로우
- [ ] 프로필 페이지 접근 및 닉네임 수정
- [ ] 모바일 반응형 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)